### PR TITLE
Keep proper type for numbers

### DIFF
--- a/tasks/convert_json.js
+++ b/tasks/convert_json.js
@@ -24,9 +24,10 @@ module.exports = function (grunt) {
     recoverProperType = function(data) {
       var type = {
         array: /\[*\]/,
-        boolean: /true|false/i
+        boolean: /true|false/i,
+        number: /^\d+$/
       };
-      if (type.array.test(data) || type.boolean.test(data)) {
+      if (type.array.test(data) || type.boolean.test(data) || type.number.test(data)) {
         return JSON.parse(data);
       }
       return data;


### PR DESCRIPTION
Fix: the recoverProperType function didn't check for numbers.
